### PR TITLE
회원가입 전달 데이터 이슈 name 삭제

### DIFF
--- a/src/main/java/com/example/bwbw/auth/dto/RequestSignUpDto.java
+++ b/src/main/java/com/example/bwbw/auth/dto/RequestSignUpDto.java
@@ -9,8 +9,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class RequestSignUpDto {
 
-    private String name;
-
     private String email;
 
     private String password;


### PR DESCRIPTION
피그마를 확인하면 회원가입 상에서 유저의 이름은 받지 않고 닉네임만 받게 되어있습니다

DB상에도 이름이 아닌 닉네임만 입력받게 되어 있기에

`RequestSignUpDto` 의 name은 nickname으로 대체되어 필요가 없는거 아닌가 했습니다

name을 왜 입력받지..?

따라서 Dto의 name필드를 삭제했습니다